### PR TITLE
Converted to common base for CSemVer[CI]

### DIFF
--- a/docfx/versioning-lib/index.md
+++ b/docfx/versioning-lib/index.md
@@ -18,7 +18,6 @@ if (actual < expectedMinimum)
 }
 
 // Good to go...
-
 ```
 
 ## Formatting
@@ -30,9 +29,17 @@ The library contains support for parsing of strings based on the rules of a
 SemVer, CSemVer, and CSemVer-CI
 
 ## Ordering
-The types all support `IComparable<T>`<sup>[1](#footnote_1)</sup> and properly handle
-correct sort ordering of the versions according to the rules of SemVer (Which, CSemVer
-and CSemVer-CI follow)
+The types all support `IComparable<T>` and properly handle correct sort ordering of the
+versions according to the rules of SemVer (Which, CSemVer and CSemVer-CI follow)
+
+>[!WARNING]
+> The [SemVer spec](https://semver.org) does not explicitly mention case sensitivity for
+> comparing the pre-release components (AlphaNumeric Identifiers) in a version. It does
+> state that they are compared lexicographically, which would imply they are case
+> sensitive. However, major repository implementations have chosen different approaches
+> to how the strings are compared and thus the ambiguities of reality win out over any
+> specified implicit behavior. Thus consumers, MUST specify the expected ordering for
+> a SemVer when creating it.
 
 >[!WARNING]
 > The formal 'spec' for [CSemVer](https://csemver.org) remains mostly silent on the point
@@ -40,16 +47,4 @@ and CSemVer-CI follow)
 > Since, the existence of that form was to support NuGet V2, which is now obsolete, this
 > library does not support the short form at all. (This choice keeps documentation
 > clarity [NOT SUPPORTED] and implementation simplicity)
-
-------
-<sup><a id="footnote_1">1</a></sup> The `SemVer` class does NOT support [`IComparable<T>`](xref:System.IComparable`1)
-as the spec is not explicit<sup>[2](#footnote_2)</sup> on case sensitive comparison of AlphaNumeric Identifiers.
-
-<sup><a id="footnote_2">2</a></sup>Technically the spec says that pre-release identifiers
-are compared lexicographically, which would mean they are case sensitive. Unfortunately,
-that was not made explicit and major repositories using SemVer have chosen to use
-different rules of comparison and ordering. Thus, a consumer is required to know a-priori
-if the version is compared insensitive or not. [`IComparer<SemVer>`](xref:System.Collections.Generic.IComparer{Ubiquity.NET.Versioning.SemVer})
-instances are available for both cases via the static class [SemVerComparer](xref:Ubiquity.NET.Versioning.SemVerComparer)
-and [CSmeVerComparer.CaseSensitive](xref:Ubiquity.NET.Versioning.SemVerComparer.CaseSensitive).
 

--- a/docfx/versioning-lib/namespaces/Ubiquit.NET.Versioning.md
+++ b/docfx/versioning-lib/namespaces/Ubiquit.NET.Versioning.md
@@ -48,17 +48,12 @@ classDiagram
         + UInt16 Revision
     }
 
-    <<struct>> FileVersionQuad
-    <<struct>> PreReleaseVersion
-    CSemVer *-- FileVersionQuad:FileVersion
+    SemVer <-- CSemVer
+    SemVer <-- CSemVerCI
+    CSemVer "1" *-- FileVersionQuad:FileVersion
     CSemVer "0..1" *-- PreReleaseVersion:PreReleaseVersion
     CSemVerCI "1" *-- CSemVer:BaseVersion
 ```
->[!IMPORTANT]
-> There is no inheritance between a `SemVer`, `CSemVer`, and `CSemVerCI`. While
-> conversion is possible in many cases they are not completely compatible due the
-> constraints on ranges and rules of ALWAYS comparing case insensitive for `CSemVer`
-> and `CSemVerCI`
 
 The primary differences between a generic SemVer, a CSemVer and CSemVerCI is in how the
 sequence of pre-release versioning components is handled and the constraints placed on
@@ -78,12 +73,12 @@ the Major, Minor and Patch version numbers.
 > AlphaNumeric Identifiers in the version. Sadly, the SemVer spec is not explicit on the
 > point of case sensitivity and various major implementations for popular frameworks have
 > chosen different approaches. Thus a consumer of a pure SemVer needs to know which kind
-> of comparison to use in order to get correct results.
+> of comparison to realize correct beavior with respect to ordering of version values.
 >
 > Due to the ambiguity of case sensitivity in ordering, it is recommended that all uses
 > of SemVer in the real world use ALL the same case (All *UPPER* or all *lower*). This
 > avoids the confusion and produces correct ordering no matter what variant of comparison
-> a consumer uses. Problems come when the version uses a *Mixed* case format.
+> a consumer uses. Problems happen ONLY when the version uses a *Mixed* case format.
 
 ### CSemVer Constraints on the integral components
 In particular the values are constrained

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -48,32 +49,41 @@ namespace Ubiquity.NET.Versioning.UT
         {
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             // VALIDATING behavior of API is the point of this test.
-            var argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(null, "c-name", null));
+            var argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(null, "c-index", null));
+            Assert.AreEqual("baseBuild", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
+
+            argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(null, "c-index", "c-name"));
+            Assert.AreEqual("baseBuild", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
+
+            argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(new CSemVer(), "c-index", null));
+            Assert.AreEqual("name", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
+
+            argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(new CSemVer(), null, "c-name"));
             Assert.AreEqual("index", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
-            var argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI(string.Empty, "c-name", null));
+            var argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI(string.Empty, "c-name", default));
             Assert.AreEqual("index", argex.ParamName, "empty string should throw");
 
-            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI(" \r\n\t", "c-name", null));
+            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI(" \r\n\t", "c-name", default));
             Assert.AreEqual("index", argex.ParamName, "all whitespace string should throw");
 
-            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("invalid#id","c-name", null));
+            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("invalid#id","c-name", default));
             Assert.AreEqual("index", argex.ParamName, "invalid index pattern should throw");
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             // VALIDATING behavior of API is the point of this test.
-            argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI("c-index", null, null));
+            argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI("c-index", null, default));
             Assert.AreEqual("name", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
-            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", string.Empty, null));
+            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", string.Empty, default));
             Assert.AreEqual("name", argex.ParamName, "empty string should throw");
 
-            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", " \r\n\t", null));
+            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", " \r\n\t", default));
             Assert.AreEqual("name", argex.ParamName, "all whitespace string should throw");
 
-            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", "invalid#id", null));
+            argex = Assert.ThrowsExactly<ArgumentException>(()=>_=new CSemVerCI("c-index", "invalid#id", default));
             Assert.AreEqual("name", argex.ParamName, "invalid name pattern should throw");
         }
 
@@ -82,7 +92,7 @@ namespace Ubiquity.NET.Versioning.UT
         public void CSemVerCITest1( )
         {
             // ZeroTime based constructor
-            string[] expectedBuildMeta = ["meta-man"];
+            ImmutableArray<string> expectedBuildMeta = ["meta-man"];
             var ver = new CSemVerCI( "c-index", "c-name", expectedBuildMeta);
 
             string[] expctedPreReleaseSeq = ["-ci", "c-index", "c-name"];

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -28,7 +29,7 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual( 0, ver.BuildMeta.Length);
 
             var preRelInfo = new PrereleaseVersion(1, 2, 3);
-            string[] expectedMeta = ["buildMeta"];
+            ImmutableArray<string> expectedMeta = ["buildMeta"];
             ver = new CSemVer( 4, 5, 6, preRelInfo, expectedMeta );
             Assert.AreEqual( 4, ver.Major );
             Assert.AreEqual( 5, ver.Minor );
@@ -41,7 +42,7 @@ namespace Ubiquity.NET.Versioning.UT
         [TestMethod]
         public void DefaultConstructorTests( )
         {
-            var ver = default( CSemVer );
+            var ver = new CSemVer( );
             Assert.AreEqual( 0, ver.Major );
             Assert.AreEqual( 0, ver.Minor );
             Assert.AreEqual( 0, ver.Patch );
@@ -107,27 +108,27 @@ namespace Ubiquity.NET.Versioning.UT
         [TestMethod]
         public void FromTest( )
         {
-            const UInt64 v0_0_0_Alpha = 1;
+            const Int64 v0_0_0_Alpha = 1;
             VerifyOrderedVersion(v0_0_0_Alpha, 0, 0, 0, 0, 0, 0);
 
-            const UInt64 v0_0_0_Alpha_0_1 = 2;
+            const Int64 v0_0_0_Alpha_0_1 = 2;
             VerifyOrderedVersion(v0_0_0_Alpha_0_1, 0, 0, 0, 0, 0, 1);
 
-            const UInt64 v0_0_0_Beta = 10001;
+            const Int64 v0_0_0_Beta = 10001;
             VerifyOrderedVersion(v0_0_0_Beta, 0, 0, 0, 1, 0, 0);
 
-            const UInt64 v20_1_4_Beta = 800010800340005ul;
+            const Int64 v20_1_4_Beta = 800010800340005L;
             VerifyOrderedVersion(v20_1_4_Beta, 20, 1, 4, 1, 0, 0);
 
-            const UInt64 v20_1_4 = 800010800410005ul;
+            const Int64 v20_1_4 = 800010800410005L;
             VerifyOrderedVersion(v20_1_4, 20, 1, 4);
 
-            const UInt64 v20_1_5_Alpha = 800010800410006ul;
+            const Int64 v20_1_5_Alpha = 800010800410006L;
             VerifyOrderedVersion(v20_1_5_Alpha, 20, 1, 5, 0, 0, 0);
         }
 
         public static void VerifyOrderedVersion(
-            UInt64 orderedVersion,
+            Int64 orderedVersion,
             int major,
             int minor,
             int patch,
@@ -153,7 +154,7 @@ namespace Ubiquity.NET.Versioning.UT
         }
 
         public static void VerifyOrderedVersion(
-            UInt64 orderedVersion,
+            Int64 orderedVersion,
             int major,
             int minor,
             int patch,

--- a/src/Ubiquity.NET.Versioning.UT/FileVersionQuadTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/FileVersionQuadTests.cs
@@ -68,7 +68,7 @@ namespace Ubiquity.NET.Versioning.Tests
         [TestMethod]
         public void FromTest( )
         {
-            var x = FileVersionQuad.From(0x123456789ABCDEF0ul);
+            var x = new FileVersionQuad(0x123456789ABCDEF0ul);
             Assert.AreEqual((UInt16)0x1234u, x.Major);
             Assert.AreEqual((UInt16)0x5678u, x.Minor);
             Assert.AreEqual((UInt16)0x9ABCu, x.Build);

--- a/src/Ubiquity.NET.Versioning.UT/SemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/SemVerTests.cs
@@ -22,31 +22,31 @@ namespace Ubiquity.NET.Versioning.UT
         public void SemVerTest( )
         {
             var sv1 = new SemVer(1, 2, 3);
-            Assert.AreEqual(1, sv1.Major);
-            Assert.AreEqual(2, sv1.Minor);
-            Assert.AreEqual(3, sv1.Patch);
-            Assert.AreEqual(0, sv1.PreRelease.Length);
-            Assert.AreEqual(0, sv1.BuildMeta.Length);
+            Assert.AreEqual( 1, sv1.Major );
+            Assert.AreEqual( 2, sv1.Minor );
+            Assert.AreEqual( 3, sv1.Patch );
+            Assert.AreEqual( 0, sv1.PreRelease.Length );
+            Assert.AreEqual( 0, sv1.BuildMeta.Length );
 
-            var sv2 = new SemVer(1, 2, 3, ["pre-rel"]);
-            Assert.AreEqual(1, sv2.Major);
-            Assert.AreEqual(2, sv2.Minor);
-            Assert.AreEqual(3, sv2.Patch);
-            Assert.AreEqual(1, sv2.PreRelease.Length);
-            Assert.AreEqual("pre-rel", sv2.PreRelease[0]);
-            Assert.AreEqual(0, sv2.BuildMeta.Length);
+            var sv2 = new SemVer(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["pre-rel"]);
+            Assert.AreEqual( 1, sv2.Major );
+            Assert.AreEqual( 2, sv2.Minor );
+            Assert.AreEqual( 3, sv2.Patch );
+            Assert.AreEqual( 1, sv2.PreRelease.Length );
+            Assert.AreEqual( "pre-rel", sv2.PreRelease[ 0 ] );
+            Assert.AreEqual( 0, sv2.BuildMeta.Length );
 
-            var sv3 = new SemVer(1, 2, 3, [], ["meta"]);
-            Assert.AreEqual(1, sv3.Major);
-            Assert.AreEqual(2, sv3.Minor);
-            Assert.AreEqual(3, sv3.Patch);
-            Assert.AreEqual(0, sv3.PreRelease.Length);
-            Assert.AreEqual(1, sv3.BuildMeta.Length);
-            Assert.AreEqual("meta", sv3.BuildMeta[0]);
+            var sv3 = new SemVer(1, 2, 3, AlphaNumericOrdering.CaseSensitive, [], ["meta"]);
+            Assert.AreEqual( 1, sv3.Major );
+            Assert.AreEqual( 2, sv3.Minor );
+            Assert.AreEqual( 3, sv3.Patch );
+            Assert.AreEqual( 0, sv3.PreRelease.Length );
+            Assert.AreEqual( 1, sv3.BuildMeta.Length );
+            Assert.AreEqual( "meta", sv3.BuildMeta[ 0 ] );
         }
 
         [TestMethod]
-        public void SortOrderIngTestsCaseInsensitive( )
+        public void SortOrderIng_is_CaseSensitive_By_Default( )
         {
             // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
             string[] verStrings = [
@@ -56,40 +56,41 @@ namespace Ubiquity.NET.Versioning.UT
                 "1.0.0-beta",
                 "1.0.0-beta.2",
                 "1.0.0-beta.11",
+                "1.0.0-Beta", // ASCII upper case should order AFTER lower case forms.
                 "1.0.0-rc.1",
                 "1.0.0",
                 "1.1.0-alpha",
+                "1.1.0-alphA",
                 "1.1.1-alpha",
                 "1.1.1",
                 "2.1.1",
             ];
 
             SemVer[] sample = [ .. verStrings.Select(s=>SemVer.Parse(s, null)) ];
-            var comparer = SemVerComparer.SemVer;
             for(int i = 1; i < verStrings.Length; ++i)
             {
                 var lhs = sample[i-1];
                 var rhs = sample[i];
 
-                Assert.IsTrue(comparer.Compare(lhs, rhs) < 0, $"'{lhs}' should compare less than '{rhs}'");
+                Assert.IsTrue( lhs.CompareTo( rhs ) < 0, $"'{lhs}' should compare less than '{rhs}'" );
 
                 // inverted should produce correct results too.
-                Assert.IsTrue(comparer.Compare(rhs, lhs) > 0, $"'{rhs}' should compare greater than '{lhs}'");
+                Assert.IsTrue( rhs.CompareTo( lhs ) > 0, $"'{rhs}' should compare greater than '{lhs}'" );
 
-                Assert.IsTrue(comparer.Compare(lhs, null) > 0, "Any version should compare greater than null");
+                Assert.IsTrue( lhs.CompareTo( null ) > 0, "Any version should compare greater than null" );
 #pragma warning disable IDE0002 // Simplify Member Access
                 // Simplification results in a different API call! Test is for a specific case
-                Assert.IsTrue(SemVer.Equals(null, null));
-                Assert.IsFalse(SemVer.Equals(lhs, null));
-                Assert.IsFalse(SemVer.Equals(null, rhs));
+                Assert.IsTrue( SemVer.Equals( null, null ) );
+                Assert.IsFalse( SemVer.Equals( lhs, null ) );
+                Assert.IsFalse( SemVer.Equals( null, rhs ) );
 #pragma warning restore IDE0002 // Simplify Member Access
 
                 var otherRef = lhs;
-                Assert.AreEqual(0, comparer.Compare(lhs, otherRef), $"'{lhs}' should be == to itself");
+                Assert.AreEqual( 0, lhs.CompareTo( otherRef ), $"'{lhs}' should be == to itself" );
 
                 // Clone it to validate value equality
-                var sameVal = new SemVer(lhs.Major, lhs.Minor, lhs.Patch, lhs.PreRelease, lhs.BuildMeta);
-                Assert.AreEqual( 0, comparer.Compare( lhs, sameVal ), "new instance of same value should be equal");
+                var sameVal = new SemVer(lhs.Major, lhs.Minor, lhs.Patch, lhs.AlphaNumericOrdering, lhs.PreRelease, lhs.BuildMeta);
+                Assert.AreEqual( 0, lhs.CompareTo( sameVal ), "new instance of same value should be equal" );
             }
         }
 
@@ -99,24 +100,24 @@ namespace Ubiquity.NET.Versioning.UT
             var verCore = new SemVer(1, 2, 3);
             Assert.AreEqual( "1.2.3", verCore.ToString() );
 
-            var verCoreWithPreRel = new SemVer(3, 4, 5, ["part1", "part2"]);
+            var verCoreWithPreRel = new SemVer(3, 4, 5, AlphaNumericOrdering.CaseSensitive, ["part1", "part2"]);
             Assert.AreEqual( "3.4.5-part1.part2", verCoreWithPreRel.ToString() );
 
-            var verCoreWith1PreRel = new SemVer(3, 4, 5, ["part1"]);
+            var verCoreWith1PreRel = new SemVer(3, 4, 5, AlphaNumericOrdering.CaseSensitive, ["part1"]);
             Assert.AreEqual( "3.4.5-part1", verCoreWith1PreRel.ToString() );
 
-            var verCoreWithBuildMeta = new SemVer(6, 7, 8, [], ["part1", "part2"] );
+            var verCoreWithBuildMeta = new SemVer(6, 7, 8, AlphaNumericOrdering.CaseSensitive, [], ["part1", "part2"] );
             Assert.AreEqual( "6.7.8+part1.part2", verCoreWithBuildMeta.ToString() );
 
-            var verCoreWith1BuildMeta = new SemVer(6, 7, 8, [], ["part1"] );
+            var verCoreWith1BuildMeta = new SemVer(6, 7, 8, AlphaNumericOrdering.CaseSensitive, [], ["part1"] );
             Assert.AreEqual( "6.7.8+part1", verCoreWith1BuildMeta.ToString() );
 
-            var verCoreWithPreRelAndBuildMeta = new SemVer(9, 10, 11, ["pr-part1", "pr-part2"], ["build1", "build2"]);
+            var verCoreWithPreRelAndBuildMeta = new SemVer(9, 10, 11, AlphaNumericOrdering.CaseSensitive, ["pr-part1", "pr-part2"], ["build1", "build2"]);
             Assert.AreEqual( "9.10.11-pr-part1.pr-part2+build1.build2", verCoreWithPreRelAndBuildMeta.ToString() );
 
             foreach(var kvp in ValidSemVerStrings)
             {
-                Assert.AreEqual(kvp.Key, kvp.Value.ToString());
+                Assert.AreEqual( kvp.Key, kvp.Value.ToString() );
             }
         }
 
@@ -132,7 +133,7 @@ namespace Ubiquity.NET.Versioning.UT
             foreach(string ver in InvalidSemVerStrings)
             {
                 // For invalid strings testing success/Failure of parse is all that's reasonably possible
-                Assert.ThrowsExactly<FormatException>(()=>_ = SemVer.Parse( ver, null));
+                Assert.ThrowsExactly<FormatException>( ( ) => _ = SemVer.Parse( ver, null ) );
             }
         }
 
@@ -171,47 +172,47 @@ namespace Ubiquity.NET.Versioning.UT
         }
 
         // Subset of valid SemVer Strings from https://regex101.com/r/Ly7O1x/3/
-        private static readonly Dictionary<string,SemVer> ValidSemVerStrings
-        = new()
-        {
-            ["0.0.4"] = new(0, 0, 4),
-            ["1.2.3"] = new(1, 2, 3),
-            ["10.20.30"] = new(10, 20, 30),
-            ["1.1.2-prerelease+meta"] = new(1, 1, 2, ["prerelease"], ["meta"]),
-            ["1.1.2+meta"] = new(1, 1, 2, [], ["meta"]),
-            ["1.1.2+meta-valid"] = new(1, 1, 2, [], ["meta-valid"]),
-            ["1.0.0-alpha"] = new(1, 0, 0, ["alpha"]),
-            ["1.0.0-beta"] = new(1, 0, 0, ["beta"]),
-            ["1.0.0-alpha.beta"] = new(1, 0, 0, ["alpha", "beta"]),
-            ["1.0.0-alpha.beta.1"] = new(1, 0, 0, ["alpha", "beta", "1"]),
-            ["1.0.0-alpha.1"] = new(1, 0, 0, ["alpha", "1"]),
-            ["1.0.0-alpha0.valid"] = new(1, 0, 0, ["alpha0", "valid"]),
-            ["1.0.0-alpha.0valid"] = new(1, 0, 0, ["alpha", "0valid"]),
-            ["1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay"] = new(1, 0, 0, ["alpha-a", "b-c-somethinglong"], ["build", "1-aef", "1-its-okay"]),
-            ["1.0.0-rc.1+build.1"] = new(1, 0, 0, ["rc", "1"], ["build", "1"]),
-            ["2.0.0-rc.1+build.123"] = new(2, 0, 0, ["rc", "1"], ["build", "123"]),
-            ["1.2.3-beta"] = new(1, 2, 3, ["beta"]),
-            ["10.2.3-DEV-SNAPSHOT"] = new(10, 2, 3, ["DEV-SNAPSHOT"]),
-            ["1.2.3-SNAPSHOT-123"] = new(1, 2, 3, ["SNAPSHOT-123"]),
-            ["1.0.0"] = new(1, 0, 0),
-            ["2.0.0"] = new(2, 0, 0),
-            ["1.1.7"] = new(1, 1, 7),
-            ["2.0.0+build.1848"] = new(2, 0, 0, [], ["build", "1848"]),
-            ["2.0.1-alpha.1227"] = new(2, 0, 1, ["alpha", "1227"]),
-            ["1.0.0-alpha+beta"] = new(1, 0, 0, ["alpha"], ["beta"]),
-            ["1.2.3----RC-SNAPSHOT.12.9.1--.12+788"] = new(1, 2, 3, ["---RC-SNAPSHOT", "12", "9", "1--", "12"], ["788"]),
-            ["1.2.3----R-S.12.9.1--.12+meta"] = new(1, 2, 3, ["---R-S", "12", "9", "1--", "12"], ["meta"]),
-            ["1.2.3----RC-SNAPSHOT.12.9.1--.12"] = new(1, 2, 3, ["---RC-SNAPSHOT", "12", "9", "1--", "12"]),
-            ["1.0.0+0.build.1-rc.10000aaa-kk-0.1"] = new(1, 0, 0, [], ["0", "build", "1-rc", "10000aaa-kk-0", "1"]),
-            ["99999999999999999999999.999999999999999999.99999999999999999"] = new( make_big_int("99999999999999999999999"), make_big_int("999999999999999999"), make_big_int("99999999999999999")),
-            ["1.0.0-0A.is.legal"] = new(1, 0, 0, ["0A", "is", "legal"]),
-        };
+        private static readonly Dictionary<string, SemVer> ValidSemVerStrings
+            = new()
+            {
+                ["0.0.4"] = new(0, 0, 4),
+                ["1.2.3"] = new(1, 2, 3),
+                ["10.20.30"] = new(10, 20, 30),
+                ["1.1.2-prerelease+meta"] = new(1, 1, 2, AlphaNumericOrdering.CaseSensitive, ["prerelease"], ["meta"]),
+                ["1.1.2+meta"] = new(1, 1, 2, AlphaNumericOrdering.CaseSensitive, [], ["meta"]),
+                ["1.1.2+meta-valid"] = new(1, 1, 2, AlphaNumericOrdering.CaseSensitive, [], ["meta-valid"]),
+                ["1.0.0-alpha"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha"]),
+                ["1.0.0-beta"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["beta"]),
+                ["1.0.0-alpha.beta"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha", "beta"]),
+                ["1.0.0-alpha.beta.1"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha", "beta", "1"]),
+                ["1.0.0-alpha.1"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha", "1"]),
+                ["1.0.0-alpha0.valid"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha0", "valid"]),
+                ["1.0.0-alpha.0valid"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha", "0valid"]),
+                ["1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha-a", "b-c-somethinglong"], ["build", "1-aef", "1-its-okay"]),
+                ["1.0.0-rc.1+build.1"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["rc", "1"], ["build", "1"]),
+                ["2.0.0-rc.1+build.123"] = new(2, 0, 0, AlphaNumericOrdering.CaseSensitive, ["rc", "1"], ["build", "123"]),
+                ["1.2.3-beta"] = new(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["beta"]),
+                ["10.2.3-DEV-SNAPSHOT"] = new(10, 2, 3, AlphaNumericOrdering.CaseSensitive, ["DEV-SNAPSHOT"]),
+                ["1.2.3-SNAPSHOT-123"] = new(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["SNAPSHOT-123"]),
+                ["1.0.0"] = new(1, 0, 0),
+                ["2.0.0"] = new(2, 0, 0),
+                ["1.1.7"] = new(1, 1, 7),
+                ["2.0.0+build.1848"] = new(2, 0, 0, AlphaNumericOrdering.CaseSensitive, [], ["build", "1848"]),
+                ["2.0.1-alpha.1227"] = new(2, 0, 1, AlphaNumericOrdering.CaseSensitive, ["alpha", "1227"]),
+                ["1.0.0-alpha+beta"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["alpha"], ["beta"]),
+                ["1.2.3----RC-SNAPSHOT.12.9.1--.12+788"] = new(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["---RC-SNAPSHOT", "12", "9", "1--", "12"], ["788"]),
+                ["1.2.3----R-S.12.9.1--.12+meta"] = new(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["---R-S", "12", "9", "1--", "12"], ["meta"]),
+                ["1.2.3----RC-SNAPSHOT.12.9.1--.12"] = new(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["---RC-SNAPSHOT", "12", "9", "1--", "12"]),
+                ["1.0.0+0.build.1-rc.10000aaa-kk-0.1"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, [], ["0", "build", "1-rc", "10000aaa-kk-0", "1"]),
+                ["99999999999999999999999.999999999999999999.99999999999999999"] = new( make_big_int("99999999999999999999999"), make_big_int("999999999999999999"), make_big_int("99999999999999999")),
+                ["1.0.0-0A.is.legal"] = new(1, 0, 0, AlphaNumericOrdering.CaseSensitive, ["0A", "is", "legal"]),
+            };
 
         [SuppressMessage( "StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "UtilityFunction - get over it!" )]
         [SuppressMessage( "Style", "IDE1006:Naming Styles", Justification = "UtilityFunction - get over it!" )]
-        private static BigInteger make_big_int(string val)
+        private static BigInteger make_big_int( string val )
         {
-            return BigInteger.Parse(val, CultureInfo.InvariantCulture);
+            return BigInteger.Parse( val, CultureInfo.InvariantCulture );
         }
 
         // Subset of invalid SemVer Strings from https://regex101.com/r/Ly7O1x/3/

--- a/src/Ubiquity.NET.Versioning/AlphaNumericOrdering.cs
+++ b/src/Ubiquity.NET.Versioning/AlphaNumericOrdering.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AlphaNumericOrdering.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Ubiquity.NET.Versioning
+{
+    /// <summary>Identifies the sort ordering expected for a given version</summary>
+    public enum AlphaNumericOrdering
+    {
+        /// <summary>Indicates no sort ordering</summary>
+        /// <remarks>
+        /// This value is the default for this type and is ALWAYS invalid.
+        /// </remarks>
+        None = 0,
+
+        /// <summary>Ordering of pre-release AlphaNumeric Identifiers uses case sensitive ordering</summary>
+        CaseSensitive,
+
+        /// <summary>Ordering of pre-release AlphaNumeric Identifiers uses case insensitive ordering</summary>
+        CaseInsensitive
+    }
+}

--- a/src/Ubiquity.NET.Versioning/CSemVer.cs
+++ b/src/Ubiquity.NET.Versioning/CSemVer.cs
@@ -5,10 +5,8 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 
 using Sprache;
 
@@ -19,13 +17,20 @@ namespace Ubiquity.NET.Versioning
     /// <summary>Holds a Constrained Semantic Version (CSemVer) value</summary>
     /// <remarks>Based on CSemVer v1.0.0-rc.1</remarks>
     /// <seealso href="https://csemver.org/"/>
-    public readonly struct CSemVer
-        : IParsable<CSemVer>
-        , IComparable<CSemVer>
-        , IComparisonOperators<CSemVer, CSemVer, bool>
-        , IEquatable<CSemVer>
+    public sealed class CSemVer
+        : SemVer
+        , IParsable<CSemVer>
     {
-        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> struct.</summary>
+        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class.</summary>
+        /// <remarks>
+        /// Default constructs a <see cref="CSemVer"/> with a version of 0.0.0 no pre-release nor build meta data
+        /// </remarks>
+        public CSemVer( )
+            : this( 0, 0, 0 )
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class.</summary>
         /// <param name="major">Major version value [0-99999]</param>
         /// <param name="minor">Minor version value [0-49999]</param>
         /// <param name="patch">Patch version value [0-9999]</param>
@@ -35,39 +40,22 @@ namespace Ubiquity.NET.Versioning
                       , int minor
                       , int patch
                       , PrereleaseVersion? preRelVersion = null
-                      , IEnumerable<string>? buildMetaData = null
+                      , ImmutableArray<string> buildMetaData = default
                       )
-        {
-            ConstrainedVersion = new SemVer(
+            : base(
                 major.ThrowIfOutOfRange( 0, 99999 ),
                 minor.ThrowIfOutOfRange( 0, 49999 ),
                 patch.ThrowIfOutOfRange( 0, 9999 ),
-                preRelVersion?.FormatElements(),
+                AlphaNumericOrdering.CaseInsensitive,
+                preRelVersion?.FormatElements().ToImmutableArray() ?? default,
                 buildMetaData
-                );
-
+                )
+        {
             PrereleaseVersion = preRelVersion;
         }
 
-        /// <summary>Gets the Major portion of the core version</summary>
-        public int Major => unchecked((int)(ConstrainedVersion?.Major ?? 0)); // explicitly unchecked as constructor guarantees success
-
-        /// <summary>Gets the Minor portion of the core version</summary>
-        public int Minor => unchecked((int)(ConstrainedVersion?.Minor ?? 0));
-
-        /// <summary>Gets the Patch portion of the core version</summary>
-        public int Patch => unchecked((int)(ConstrainedVersion?.Patch ?? 0));
-
         /// <summary>Gets the Pre-Release version value (if any)</summary>
         public PrereleaseVersion? PrereleaseVersion { get; }
-
-        /// <summary>Gets the build components of the version</summary>
-        /// <remarks>
-        /// Each component is either an alphanumeric identifier or a sequence of digits
-        /// (including leading or all '0'). This collection contains only the identifiers
-        /// (no prefix or delimiters).
-        /// </remarks>
-        public ImmutableArray<string> BuildMeta => ConstrainedVersion?.BuildMeta ?? [];
 
         /// <summary>Gets the <see cref="FileVersionQuad"/> representation of this <see cref="CSemVer"/></summary>
         /// <remarks>
@@ -77,14 +65,7 @@ namespace Ubiquity.NET.Versioning
         /// same value! CI builds are not intended for long term stability and this is not a bug but a design of
         /// how CSemVer (and CSemVer-CI) work to produce a <see cref="FileVersionQuad"/>.
         /// </remarks>
-        public FileVersionQuad FileVersion
-        {
-            get
-            {
-                ulong orderedNum = OrderedVersion << 1;
-                return FileVersionQuad.From( orderedNum + 1 ); // ODD numbers reserved for CI versions that are always "post-build"
-            }
-        }
+        public FileVersionQuad FileVersion => new( OrderedVersion, isCiBuild: false );
 
         /// <summary>Gets the CSemVer ordered version value of the version</summary>
         /// <remarks>
@@ -92,11 +73,11 @@ namespace Ubiquity.NET.Versioning
         /// except that it does NOT include any information about whether it is a CI build
         /// or not.
         /// </remarks>
-        public ulong OrderedVersion
+        public Int64 OrderedVersion
         {
             get
             {
-                ulong retVal = ((ulong)Major * MulMajor) + ((ulong)Minor * MulMinor) + (((ulong)Patch + 1) * MulPatch);
+                UInt64 retVal = ((UInt64)Major * MulMajor) + ((UInt64)Minor * MulMinor) + (((UInt64)Patch + 1) * MulPatch);
 
                 if(PrereleaseVersion.HasValue)
                 {
@@ -106,7 +87,7 @@ namespace Ubiquity.NET.Versioning
                     retVal += PrereleaseVersion.Value.Fix;
                 }
 
-                return retVal;
+                return checked((Int64)retVal);
             }
         }
 
@@ -115,64 +96,6 @@ namespace Ubiquity.NET.Versioning
 
         /// <summary>Gets a value indicating whether this is a zero based version</summary>
         public bool IsZero => Major == 0 && Minor == 0 && Patch == 0;
-
-        /// <summary>Converts the internal representation of this version to a valid CSemVer formatted string</summary>
-        /// <returns>CSemVer formatted string</returns>
-        public override string ToString( )
-        {
-            return ConstrainedVersion?.ToString() ?? string.Empty;
-        }
-
-        /// <inheritdoc/>
-        /// <remarks>
-        /// <see cref="CSemVer"/> follows ALL of the rules of SemVer ordering EXCEPT
-        /// that it is EXPLICITLY using case insensitive comparison for the AlphaNumeric
-        /// identifiers in a pre-release list.
-        /// </remarks>
-        public int CompareTo( CSemVer other )
-        {
-            // CSemVer always uses case insensitive comparisons, but otherwise follows the
-            // ordering rules of SemVer.
-            return SemVerComparer.SemVer.Compare(ConstrainedVersion, other.ConstrainedVersion);
-        }
-
-        /// <inheritdoc/>
-        public bool Equals( CSemVer other )
-        {
-            return CompareTo( other ) == 0;
-        }
-
-        /// <inheritdoc/>
-        public override bool Equals( object? obj )
-        {
-            return obj is CSemVer v && Equals(v);
-        }
-
-        /// <inheritdoc/>
-        public override int GetHashCode( )
-        {
-            return ConstrainedVersion?.GetHashCode() ?? 0;
-        }
-
-        /// <inheritdoc/>
-        public static bool operator >( CSemVer left, CSemVer right ) => left.CompareTo(right) > 0;
-
-        /// <inheritdoc/>
-        public static bool operator >=( CSemVer left, CSemVer right ) => left.CompareTo(right) >= 0;
-
-        /// <inheritdoc/>
-        public static bool operator <( CSemVer left, CSemVer right ) => left.CompareTo(right) < 0;
-
-        /// <inheritdoc/>
-        public static bool operator <=( CSemVer left, CSemVer right ) => left.CompareTo(right) <= 0;
-
-        /// <inheritdoc/>
-        public static bool operator ==( CSemVer left, CSemVer right ) => Equals(left, right);
-
-        /// <inheritdoc/>
-        public static bool operator !=( CSemVer left, CSemVer right ) => !Equals(left, right);
-
-        private readonly SemVer? ConstrainedVersion;
 
         /// <summary>Tries to parse a <see cref="SemVer"/> as a <see cref="CSemVer"/></summary>
         /// <param name="ver">Version to convert</param>
@@ -198,7 +121,7 @@ namespace Ubiquity.NET.Versioning
             // CSemVer.2 (Partial: max is 3 components)
             if(ver.PreRelease.Length.IsOutOfRange( 0, 3 ))
             {
-                reason = new FormatException(Resources.CSemVer_pre_release_supports_no_more_than_3_components_0.Format( "[CSemVer.2]" ));
+                reason = new FormatException( Resources.CSemVer_pre_release_supports_no_more_than_3_components_0.Format( "[CSemVer.2]" ) );
                 return false;
             }
 
@@ -206,25 +129,25 @@ namespace Ubiquity.NET.Versioning
             // CSemVer.4
             if(ver.Major.IsOutOfRange( 0, 99999 ))
             {
-                reason = new FormatException(Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Major", "[0-99999]", "[CSemVer.4]" ));
+                reason = new FormatException( Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Major", "[0-99999]", "[CSemVer.4]" ) );
                 return false;
             }
 
             // CSemVer.5
             if(ver.Minor.IsOutOfRange( 0, 49999 ))
             {
-                reason = new FormatException(Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Minor", "[0-49999]", "[CSemVer.5]" ));
+                reason = new FormatException( Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Minor", "[0-49999]", "[CSemVer.5]" ) );
                 return false;
             }
 
             if(ver.Patch.IsOutOfRange( 0, 9999 ))
             {
-                reason = new FormatException(Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Patch", "[0-9999]", "[CSemVer.6]" ));
+                reason = new FormatException( Resources.value_0_must_be_in_range_1_2.Format( "CSemVer.Patch", "[0-9999]", "[CSemVer.6]" ) );
                 return false;
             }
 
             IResult<PrereleaseVersion> preRel = Versioning.PrereleaseVersion.TryParseFrom( ver.PreRelease );
-            if(preRel.Failed(out reason))
+            if(preRel.Failed( out reason ))
             {
                 return false;
             }
@@ -261,23 +184,24 @@ namespace Ubiquity.NET.Versioning
         /// includes a "bit" for the status as a CI Build. Thus a "file version" as a <see cref="UInt64"/> is the ordered version shifted
         /// left by one bit and the LSB indicates if it is a CI build or release</para>
         /// </remarks>
-        public static CSemVer From( UInt64 fileVersion, IReadOnlyCollection<string>? buildMetaData = null )
+        public static CSemVer From( FileVersionQuad fileVersion, ImmutableArray<string> buildMetaData = default )
         {
-            return (fileVersion & 1) == 1
-                ? FromOrderedVersion( fileVersion >> 1, buildMetaData )
-                : throw new ArgumentException( Resources.odd_file_versions_are_reserved_for_CI );
+            // Drop the CI bit to get an ordered version
+            return !fileVersion.IsCiBuild
+                ? FromOrderedVersion( fileVersion.ToOrderedVersion(), buildMetaData )
+                : throw new ArgumentException( "FileVersionQuad for a CI build cannot be used to create a non CI version", nameof( fileVersion ) );
         }
 
         /// <summary>Converts a CSemVer ordered version integral value (UInt64) into a full <see cref="CSemVer"/></summary>
         /// <param name="orderedVersion">The ordered version value</param>
         /// <param name="buildMetaData">Optional build meta data value for the version</param>
         /// <returns>Version corresponding to the ordered version number provided</returns>
-        public static CSemVer FromOrderedVersion( UInt64 orderedVersion, IReadOnlyCollection<string>? buildMetaData = null )
+        public static CSemVer FromOrderedVersion( Int64 orderedVersion, ImmutableArray<string> buildMetaData = default )
         {
-            buildMetaData ??= [];
+            ArgumentOutOfRangeException.ThrowIfGreaterThan( orderedVersion, MaxOrderedVersion );
 
             // This effectively reverses the math used in computing the ordered version.
-            UInt64 accumulator = orderedVersion;
+            UInt64 accumulator = (UInt64)orderedVersion;
             UInt64 preRelPart = accumulator % MulPatch;
             PrereleaseVersion? preRelVersion = null;
             if(preRelPart != 0)
@@ -313,7 +237,7 @@ namespace Ubiquity.NET.Versioning
         /// <param name="buildVersionXmlPath">Path to the BuildVersion XML data for the repository</param>
         /// <param name="buildMeta">Additional Build meta data for the build</param>
         /// <returns>Version information parsed from the build XML</returns>
-        public static CSemVer From( string buildVersionXmlPath, IReadOnlyCollection<string>? buildMeta )
+        public static CSemVer From( string buildVersionXmlPath, ImmutableArray<string> buildMeta )
         {
             var parsedBuildVersionXml = ParsedBuildVersionXml.ParseFile( buildVersionXmlPath );
 
@@ -327,17 +251,18 @@ namespace Ubiquity.NET.Versioning
             }
 
             return new CSemVer( parsedBuildVersionXml.BuildMajor
-                                , parsedBuildVersionXml.BuildMinor
-                                , parsedBuildVersionXml.BuildPatch
-                                , preReleaseVersion
-                                , buildMeta
-                                );
+                              , parsedBuildVersionXml.BuildMinor
+                              , parsedBuildVersionXml.BuildPatch
+                              , preReleaseVersion
+                              , buildMeta
+                              );
         }
 
         /// <inheritdoc/>
-        public static CSemVer Parse( string s, IFormatProvider? provider )
+        public static new CSemVer Parse( string s, IFormatProvider? provider )
         {
-            return TryParse(s, out CSemVer retVal, out Exception? ex) ? retVal : throw ex;
+            provider.ThrowIfCaseSensitive();
+            return TryParse( s, out CSemVer? retVal, out Exception? ex ) ? retVal : throw ex;
         }
 
         /// <inheritdoc/>
@@ -346,7 +271,8 @@ namespace Ubiquity.NET.Versioning
         /// </remarks>
         public static bool TryParse( [NotNullWhen( true )] string? s, IFormatProvider? provider, [MaybeNullWhen( false )] out CSemVer result )
         {
-            return TryParse(s, out result, out _);
+            provider.ThrowIfCaseSensitive();
+            return TryParse( s, out result, out _ );
         }
 
         /// <summary>Applies try pattern to attempt parsing a <see cref="CSemVer"/> from a string</summary>
@@ -354,33 +280,44 @@ namespace Ubiquity.NET.Versioning
         /// <param name="result">Resulting version or default if parse is successful</param>
         /// <param name="reason">Reason for failure to parse (as an <see cref="Exception"/>)</param>
         /// <returns><see langword="true"/> if parse is successful or <see langword="false"/> if not</returns>
+        [SuppressMessage( "Style", "IDE0002:Simplify Member Access", Justification = "More explicit this way" )]
         public static bool TryParse(
             [NotNullWhen( true )] string? s,
             [MaybeNullWhen( false )] out CSemVer result,
-            [MaybeNullWhen(true)] out Exception reason
+            [MaybeNullWhen( true )] out Exception reason
             )
         {
-            if(string.IsNullOrWhiteSpace(s))
+            if(string.IsNullOrWhiteSpace( s ))
             {
                 result = default;
-                reason = new ArgumentException(Resources.value_is_null_or_whitespace, nameof(s));
+                reason = new ArgumentException( Resources.value_is_null_or_whitespace, nameof( s ) );
                 return false;
             }
 
-            if(!SemVer.TryParse( s, out SemVer? semVer, out reason))
+            if(!SemVer.TryParse( s, SemVerFormatProvider.CaseInsensitive, out SemVer? semVer, out reason ))
             {
                 result = default;
                 return false;
             }
 
             // OK as a SemVer, so try and see if that conforms to a constrained form.
-            return TryFrom(semVer, out result, out reason);
+            return TryFrom( semVer, out result, out reason );
         }
 
-        private const ulong MulNum = 100;
-        private const ulong MulName = MulNum * 100;
-        private const ulong MulPatch = (MulName * 8) + 1;
-        private const ulong MulMinor = MulPatch * 10000;
-        private const ulong MulMajor = MulMinor * 50000;
+        /// <summary>Maximum value of an ordered version number</summary>
+        /// <remarks>
+        /// This represents a version of v99999.49999.9999. No CSemVer greater than
+        /// this value is possible. Thus, no CI build is based on this version either.
+        /// </remarks>
+        public const Int64 MaxOrderedVersion = 4000050000000000000L;
+
+        // v5.0.4 => 200002500400005;
+        // v5.0.5 => 200002500480006;  (previous + MulPatch!)
+
+        internal const ulong MulNum = 100;
+        internal const ulong MulName = MulNum * 100;        // 10,000
+        internal const ulong MulPatch = (MulName * 8) + 1;  // 80,001
+        internal const ulong MulMinor = MulPatch * 10000;   // 800,010,000
+        internal const ulong MulMajor = MulMinor * 50000;   // 4,000,050,000,000
     }
 }

--- a/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
+++ b/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
@@ -5,15 +5,12 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace Ubiquity.NET.Versioning
 {
     /// <summary>Represents a traditional "File" version QUAD of 16bit values</summary>
-    /// <param name="Major">Major version number</param>
-    /// <param name="Minor">Minor version number</param>
-    /// <param name="Build">Build version number</param>
-    /// <param name="Revision">Revision number</param>
     /// <remarks>
     /// <para>The "FILEVERSION" structure was first used in Windows as part of the Resource compiler's
     /// "VERSION" information (Still used to this day). However, it's use in other places exists
@@ -44,17 +41,94 @@ namespace Ubiquity.NET.Versioning
     /// ordered version shifted left by one bit and the LSB indicates if it is a Release/CI build</para>
     /// </remarks>
     /// <seealso href="https://csemver.org/"/>
-    public readonly record struct FileVersionQuad( UInt16 Major, UInt16 Minor, UInt16 Build, UInt16 Revision )
+    public readonly record struct FileVersionQuad
         : IComparable<FileVersionQuad>
         , IComparisonOperators<FileVersionQuad, FileVersionQuad, bool>
     {
+        /// <summary>Initializes a new instance of the <see cref="FileVersionQuad"/> struct.</summary>
+        /// <param name="major">Major component of the version Quad</param>
+        /// <param name="minor">Minor component of the version Quad</param>
+        /// <param name="build">Build component of the version Quad</param>
+        /// <param name="revision">Revision component of the version Quad</param>
+        public FileVersionQuad( UInt16 major, UInt16 minor, UInt16 build, UInt16 revision )
+        {
+            FileVersion64 = ((UInt64)major << 48)
+                          + ((UInt64)minor << 32)
+                          + ((UInt64)build << 16)
+                          + revision;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="FileVersionQuad"/> struct.</summary>
+        /// <param name="fileVersion64">Unsigned 64 bit representation of a file version Quad</param>
+        public FileVersionQuad( UInt64 fileVersion64 )
+        {
+            FileVersion64 = fileVersion64;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="FileVersionQuad"/> struct.</summary>
+        /// <param name="orderedVersion">Ordered version number to build the Quad from</param>
+        /// <param name="isCiBuild">Boolean indicator of whether the version is a CI build or not</param>
+        /// <remarks>
+        /// CI build information is NOT included in an ordered version thus it is a required parameter
+        /// when converting. The <paramref name="isCiBuild"/> parameter also helps differentiate the
+        /// constructor overloads with the <see cref="FileVersionQuad.FileVersionQuad(ulong)"/> form as
+        /// both use a 64 bit value (signed vs. unsigned) to represent very different things.
+        /// </remarks>
+        public FileVersionQuad( Int64 orderedVersion, bool isCiBuild )
+        {
+            // if the upper bit is set, it isn't a valid ordered version...
+            if(orderedVersion < 0)
+            {
+                throw new ArgumentOutOfRangeException( nameof( orderedVersion ), "Invalid ordered version; Upper bit is set!" );
+            }
+
+            FileVersion64 = ((UInt64)orderedVersion << 1) + (isCiBuild ? 1ul : 0ul);
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="FileVersionQuad"/> struct.</summary>
+        /// <param name="v">Version to initialize from</param>
+        /// <exception cref="ArgumentOutOfRangeException">One of the components of <paramref name="v"/> is too large to fit in a unsigned 16 bit value</exception>
+        public FileVersionQuad( Version v )
+            : this( (UInt16)v.Major.ThrowIfGreaterThan( UInt16.MaxValue ),
+                    (UInt16)v.Minor.ThrowIfGreaterThan( UInt16.MaxValue ),
+                    (UInt16)v.Build.ThrowIfGreaterThan( UInt16.MaxValue ),
+                    (UInt16)v.Revision.ThrowIfGreaterThan( UInt16.MaxValue )
+                  )
+        {
+        }
+
         /// <summary>Gets a value indicating whether this version is a CI build</summary>
         public bool IsCiBuild => (Revision & 1) == 1; // 1 indicates a CI build with a higher sort order.
+
+        /// <summary>Gets the Major component of the version number</summary>
+        public UInt16 Major => (UInt16)(FileVersion64 >> 48);
+
+        /// <summary>Gets the Major component of the version number</summary>
+        public UInt16 Minor => (UInt16)(FileVersion64 >> 32);
+
+        /// <summary>Gets the Major component of the version number</summary>
+        public UInt16 Build => (UInt16)(FileVersion64 >> 16);
+
+        /// <summary>Gets the Major component of the version number</summary>
+        public UInt16 Revision => (UInt16)(FileVersion64);
+
+        /// <summary>Gets the UInt64 representation of the version</summary>
+        /// <returns>UInt64 version of the version</returns>
+        /// <remarks>
+        /// The value is independent of system "endianness" and consists of the multiple parts
+        /// corresponding to four 16 bit wide fields. In order of significance those values are:
+        /// Major, Minor, Build, Revision. Thus, while the actual byte ordering of the data making
+        /// up an integral value will depend on the system architecture, it's VALUE does not.
+        /// </remarks>
+        public UInt64 ToUInt64( )
+        {
+            return FileVersion64;
+        }
 
         /// <inheritdoc/>
         public int CompareTo( FileVersionQuad other )
         {
-            return ToUInt64().CompareTo(other.ToUInt64());
+            return FileVersion64.CompareTo( other.FileVersion64 );
         }
 
         /// <inheritdoc/>
@@ -69,22 +143,6 @@ namespace Ubiquity.NET.Versioning
         /// <inheritdoc/>
         public static bool operator >=( FileVersionQuad left, FileVersionQuad right ) => left.CompareTo( right ) >= 0;
 
-        /// <summary>Gets the UInt64 representation of the version</summary>
-        /// <returns>UInt64 version of the version</returns>
-        /// <remarks>
-        /// The value is independent of system "endianness" and consists of the multiple parts
-        /// corresponding to four 16 bit wide fields. In order of significance those values are:
-        /// Major, Minor, Build, Revision. Thus, while the actual byte ordering of the data making
-        /// up an integral value will depend on the system architecture, it's VALUE does not.
-        /// </remarks>
-        public UInt64 ToUInt64( )
-        {
-            return ((UInt64)Major << 48)
-                 + ((UInt64)Minor << 32)
-                 + ((UInt64)Build << 16)
-                 + Revision;
-        }
-
         /// <summary>Gets the CSemVer defined ordered version number for this FileVersion quad</summary>
         /// <param name="isCIBuild">Indicates if the File Version is for a CI build or not</param>
         /// <returns>Ordered version number of this file version</returns>
@@ -92,16 +150,16 @@ namespace Ubiquity.NET.Versioning
         /// The File version form of a CSemVer value includes a bit to indicate if the version is a CI build
         /// or not. This condition is important for ordering
         /// </remarks>
-        public UInt64 ToOrderedVersion(out bool isCIBuild)
+        public Int64 ToOrderedVersion( out bool isCIBuild )
         {
             isCIBuild = IsCiBuild;
-            return ToUInt64() >> 1;
+            return (Int64)(FileVersion64 >> 1);
         }
 
         /// <inheritdoc cref="ToOrderedVersion(out bool)"/>
-        public UInt64 ToOrderedVersion()
+        public Int64 ToOrderedVersion( )
         {
-            return ToOrderedVersion(out _);
+            return ToOrderedVersion( out _ );
         }
 
         /// <summary>Converts this instance to a <see cref="Version"/></summary>
@@ -120,40 +178,64 @@ namespace Ubiquity.NET.Versioning
             return new Version( Major, Minor, Build, Revision );
         }
 
+        /// <summary>Converts this instance to a <see cref="SemVer"/> derived constrained type</summary>
+        /// <returns>Constrained version type</returns>
+        /// <remarks>The result is either a <see cref="CSemVerCI"/> or <see cref="CSemVer"/> depending
+        /// on the state of the <see cref="IsCiBuild"/> property. This is used in consuming code when
+        /// it gets only the file version as a 64bit value or a <see cref="FileVersionQuad"/> to produce
+        /// a correct version. Usually a consumer won't care and is only concerned with ordering but
+        /// if needed simple "is" testing is available.
+        /// </remarks>
+        /// <example>
+        /// <code><![CDATA[
+        /// FileVersionQuad quad;
+        /// // ...
+        /// SemVer ver = quad.ToSemVer();
+        /// if(ver > MinimumVer)
+        /// {
+        ///     // Good to go!
+        ///     if( ver is CSmeVerCI)
+        ///     {
+        ///         // and it's a CI build!
+        ///     }
+        /// }
+        ///
+        /// // ...
+        /// static readonly CSemVer MinimumVer = new(1,2,3);
+        /// ]]></code>
+        /// </example>
+        public SemVer ToSemVer()
+        {
+            return IsCiBuild ? CSemVerCI.From(this) : CSemVer.From(this);
+        }
+
         /// <summary>Converts this instance to a dotted string form</summary>
         /// <returns>Formatted string</returns>
         public override string ToString( ) => $"{Major}.{Minor}.{Build}.{Revision}";
 
-        /// <summary>Converts a <see cref="Version"/> value to a <see cref="FileVersionQuad"/> if possible</summary>
-        /// <param name="v">Version to convert</param>
-        /// <returns>Resulting <see cref="FileVersionQuad"/></returns>
-        /// <exception cref="ArgumentOutOfRangeException">At least one of the members of <paramref name="v"/> is out of range of a <see cref="UInt16"/></exception>
-        public static FileVersionQuad From( Version v)
-        {
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Major, UInt16.MaxValue);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Minor, UInt16.MaxValue);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Build, UInt16.MaxValue);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Revision, UInt16.MaxValue);
+        private readonly UInt64 FileVersion64;
 
-            return new((UInt16)v.Major, (UInt16)v.Minor, (UInt16)v.Build, (UInt16)v.Revision);
+        /// <summary>explicit cast of a <see cref="FileVersionQuad"/> as a version</summary>
+        /// <param name="v">Value to cast</param>
+        public static explicit operator Version( FileVersionQuad v )
+        {
+            return v.ToVersion();
         }
 
-        /// <summary>Converts a version integral value into a <see cref="FileVersionQuad"/></summary>
-        /// <param name="value">Value to convert</param>
-        /// <returns> <see cref="FileVersionQuad"/> variant of <paramref name="value"/></returns>
-        public static FileVersionQuad From( UInt64 value )
+        /// <summary>Explicit cast operator from a <see cref="Version"/> to a <see cref="FileVersionQuad"/></summary>
+        /// <param name="v">Version to convert</param>
+        [SuppressMessage( "Usage", "CA2225:Operator overloads have named alternates", Justification = "Constructor exists" )]
+        public static explicit operator FileVersionQuad( Version v )
         {
-            UInt16 revision = (UInt16)(value % 65536);
-            UInt64 rem = (value - revision) / 65536;
+            return new( v );
+        }
 
-            UInt16 build = (UInt16)(rem % 65536);
-            rem = (rem - build) / 65536;
-
-            UInt16 minor = (UInt16)(rem % 65536);
-            rem = (rem - minor) / 65536;
-
-            UInt16 major = (UInt16)(rem % 65536);
-            return new( major, minor, build, revision );
+        /// <summary>Explicit cast operator from a <see cref="UInt64"/> raw value to a <see cref="FileVersionQuad"/></summary>
+        /// <param name="v">Version to convert</param>
+        [SuppressMessage( "Usage", "CA2225:Operator overloads have named alternates", Justification = "Constructor exists" )]
+        public static explicit operator FileVersionQuad( UInt64 v )
+        {
+            return new( v );
         }
     }
 }

--- a/src/Ubiquity.NET.Versioning/FormatProviderExtensions.cs
+++ b/src/Ubiquity.NET.Versioning/FormatProviderExtensions.cs
@@ -1,0 +1,26 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FormatProviderExtensions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Ubiquity.NET.Versioning
+{
+    internal static class FormatProviderExtensions
+    {
+        public static void ThrowIfCaseSensitive(this IFormatProvider? provider, [CallerArgumentExpression(nameof(provider))] string? exp = null)
+        {
+            if(provider is not null)
+            {
+                var ordering = (AlphaNumericOrdering?)provider.GetFormat(typeof(AlphaNumericOrdering));
+                if(ordering is not null && ordering.Value == AlphaNumericOrdering.CaseSensitive)
+                {
+                    throw new ArgumentException("Format provider must be <null> or provide a CaseInsensitive comparison", exp);
+                }
+            }
+        }
+    }
+}

--- a/src/Ubiquity.NET.Versioning/SemVerFormatProvider.cs
+++ b/src/Ubiquity.NET.Versioning/SemVerFormatProvider.cs
@@ -1,0 +1,44 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="SemVerFormatProvider.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Ubiquity.NET.Versioning
+{
+    /// <summary>Format provider for a Semantic version that determines the ordering for parsing</summary>
+    /// <remarks>
+    /// SemVer has a culture neutral formatting when converted to a string and this is not needed for that
+    /// scenario. However, for parsing a <see cref="SemVer"/> is created and that needs to know what ordering
+    /// should apply to the resulting version. Thus, the static members of this class handle setting that
+    /// based on whether the source is case sensitive or not.
+    /// <note type="note">
+    /// <see cref="CSemVer"/> and <see cref="CSemVerCI"/> ALWAYS use a Case Sensitive comparison and therefore
+    /// parsing those, using this formatter is ignored.
+    /// </note>
+    /// </remarks>
+    public sealed class SemVerFormatProvider
+        : IFormatProvider
+    {
+        internal SemVerFormatProvider( AlphaNumericOrdering ordering )
+        {
+            Ordering = ordering;
+        }
+
+        internal AlphaNumericOrdering Ordering { get; }
+
+        /// <inheritdoc/>
+        object? IFormatProvider.GetFormat( Type? formatType )
+        {
+            return formatType == typeof(AlphaNumericOrdering) ? Ordering : null;
+        }
+
+        /// <summary>Gets a formatter that supports case sensitive comparisons of parsed <see cref="SemVer"/> values</summary>
+        public static readonly IFormatProvider CaseSensitive = new SemVerFormatProvider(AlphaNumericOrdering.CaseSensitive);
+
+        /// <summary>Gets a formatter that supports case insensitive comparisons of parsed <see cref="SemVer"/> values</summary>
+        public static readonly IFormatProvider CaseInsensitive = new SemVerFormatProvider(AlphaNumericOrdering.CaseInsensitive);
+    }
+}

--- a/src/Ubiquity.NET.Versioning/SemVerGrammar.cs
+++ b/src/Ubiquity.NET.Versioning/SemVerGrammar.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -107,11 +108,13 @@ namespace Ubiquity.NET.Versioning
                from patch in IntegralValue.Named("<patch>")
                select new SemVer( major, minor, patch );
 
-        internal static Parser<SemVer> SemanticVersion
+        // NOTE: ordering does not impact the parsing, but it does alter the behavior of the parsed result
+        //       and therefore MUST be provided to construct the result.
+        internal static Parser<SemVer> SemanticVersion(AlphaNumericOrdering ordering)
             => ( from vc in VersionCore.Named("<version core>")
                  from preRel in PreReleaseData.Named("<pre-release>").XOptional()
                  from build in BuildMetaData.Named("<build>").XOptional()
-                 select new SemVer(vc.Major, vc.Minor, vc.Patch, preRel.GetOrElse([]), build.GetOrElse([]))
+                 select new SemVer(vc.Major, vc.Minor, vc.Patch, ordering, [ .. preRel.GetOrElse([]) ], [ .. build.GetOrElse([]) ] )
                ).End();
     }
 }

--- a/src/Ubiquity.NET.Versioning/ValidateArg.cs
+++ b/src/Ubiquity.NET.Versioning/ValidateArg.cs
@@ -52,6 +52,14 @@ namespace Ubiquity.NET.Versioning
                 : self;
         }
 
+        public static T ThrowIfGreaterThan<T>( [NotNull] this T? self, T other, [CallerArgumentExpression( nameof( self ) )] string? exp = null )
+            where T : IComparable<T>
+        {
+            self.ThrowIfNull( exp );
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(self, other, exp);
+            return self;
+        }
+
         public static T ThrowIfNull<T>( [NotNull] this T? self, [CallerArgumentExpression( nameof( self ) )] string? exp = null )
         {
             return self is not null ? self : throw new ArgumentNullException( exp );


### PR DESCRIPTION
Resolves #1
* Updated core to support type hierarchy and conversion of a constrained version from a FileVersionQuad.
    - CSemVer and CSemVer-CI are not compatible and do NOT follow each others rules but they do follow a constrained subset of the rules for SemVer.
- Comparison is now built-into the SemVer type
    - Comparison follows whatever form was defined for the value at time of construction.
    - Forced override is available in the Versioning.Comparison.* types.
- More testing is needed including a "beta" period that involves consumers.
- Update Docs To reflect change in usage