### PR TITLE
Changed release build action to not publish to NuGet

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,7 +4,7 @@ permissions:
   pages: write
   packages: write
   actions: read
-  
+
 defaults:
   run:
     shell: pwsh
@@ -67,13 +67,16 @@ jobs:
           directory: .\BuildOutput\docs
           branch: gh-pages
 
-      - name: Publish packages to NuGet.org
-        run: |
-          if( [string]::IsNullOrWhiteSpace('${{secrets.NUGETPUSH_ACCESS_TOKEN}}'))
-          {
-              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist, is empty or all whitespace!"
-          }
-          dotnet nuget push .\BuildOutput\NuGet\*.nupkg --api-key '${{secrets.NUGETPUSH_ACCESS_TOKEN}}' --source 'https://api.nuget.org/v3/index.json' --skip-duplicate
+# no automatic publication of NuGet packages, too much room for mistakes as publication to NuGet
+# cannot be undone. The packages must be manually published AFTER a successful GH release process
+# as a GH release ca be undone!
+#      - name: Publish packages to NuGet.org
+#        run: |
+#          if( [string]::IsNullOrWhiteSpace('${{secrets.NUGETPUSH_ACCESS_TOKEN}}'))
+#          {
+#              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist, is empty or all whitespace!"
+#          }
+#          dotnet nuget push .\BuildOutput\NuGet\*.nupkg --api-key '${{secrets.NUGETPUSH_ACCESS_TOKEN}}' --source 'https://api.nuget.org/v3/index.json' --skip-duplicate
 
       - name: Create Release
         if: (!cancelled())


### PR DESCRIPTION
Changed release build action to not publish to NuGet
- Multiple releases have shown that is problematic to do automated.
    - Everything else can be "undone" in some form. Publication to NuGet cannot. Thus, EXTREME care needs to come into play for any publication of packages. It can be scripted for simplification, but automated publication is causing too many
issues with deprecations and de-listing etc...