### PR TITLE
PR/CI build update

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,6 +14,7 @@ on:
       - '**.md'
       - '**.dic'
       - 'BuildVersion.xml'
+      - 'GitHub/workflows/release-build.yml'
 
   pull_request:
     branches:
@@ -23,6 +24,7 @@ on:
       - '**.md'
       - '**.dic'
       - 'BuildVersion.xml'
+      - 'GitHub/workflows/release-build.yml'
 
 jobs:
   # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches


### PR DESCRIPTION
PR/CI build update
- Added ignore of release build action file as it will have no impact on the resulting build. (Not used for a PR/CI build)