### PR TITLE
Updates for WhatIf/Confirm standard processing for OneFlow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,7 @@ on:
       - '**.dic'
       - 'BuildVersion.xml'
       - 'GitHub/workflows/release-build.yml'
+      - 'OneFlow/**.ps1'
 
   pull_request:
     branches:
@@ -25,6 +26,7 @@ on:
       - '**.dic'
       - 'BuildVersion.xml'
       - 'GitHub/workflows/release-build.yml'
+      - 'OneFlow/**.ps1'
 
 jobs:
   # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches

--- a/OneFlow/Start-Release.ps1
+++ b/OneFlow/Start-Release.ps1
@@ -12,8 +12,10 @@ using module '../PsModules/RepoBuild/RepoBuild.psd1'
 .DESCRIPTION
     This function creates and publishes a Release branch
 #>
-
-Param([string]$commit = "")
+[cmdletbinding(SupportsShouldProcess=$True)]
+Param(
+    [string]$commit = ""
+)
 $buildInfo = Initialize-BuildEnvironment
 
 $officialRemoteName = Get-GitRemoteName $buildInfo official
@@ -24,18 +26,24 @@ $branchName = "release/$(Get-BuildVersionTag $buildInfo)"
 Write-Information "Creating release branch in local repo"
 if ([string]::IsNullOrWhiteSpace($commit))
 {
-    Invoke-External git checkout -b $branchName
+    if($PSCmdlet.ShouldProcess($branchName, "git checkout -b"))
+    {
+        Invoke-External git checkout -b $branchName
+    }
 }
 else
 {
-    Invoke-External git checkout -b $branchName $commit
+    if($PSCmdlet.ShouldProcess("$branchName $commit", "git checkout -b"))
+    {
+        Invoke-External git checkout -b $branchName $commit
+    }
 }
-
-# push to fork so that changes go through normal PR process
-Write-Information "Pushing branch to fork"
-Invoke-External git push $forkRemoteName -u $branchName
 
 # Push to product repo so it is clear to all a release
 # is in process.
 Write-Information "Pushing branch to official repository (Push/Write permission required)"
-Invoke-External git push $officialRemoteName $branchName
+if($PSCmdlet.ShouldProcess("$officialRemoteName $branchName", "git push"))
+{
+    Invoke-External git push $officialRemoteName $branchName
+}
+

--- a/PsModules/CommonBuild/Private/Get-BuildVersionXML.ps1
+++ b/PsModules/CommonBuild/Private/Get-BuildVersionXML.ps1
@@ -12,9 +12,24 @@ function Get-BuildVersionXML
     Hashtable containing Information about the repository and build. This function
     requires the presence of a 'RepoRootPath' property to indicate the root of the
     repository containing the BuildVersion.xml file.
+
+.PARAMETER xmlPath
+    Path of the XML file to retrieve. This is mutually exclusive with the BuildInfo
+    parameter, it is generally only used when developing these build scripts to
+    explicitly retrieve the version from a path without needing the hashtable.
 #>
     [OutputType([xml])]
-    param ($buildInfo)
+    param (
+        [Parameter(Mandatory=$true, ParameterSetName = 'BuildInfo', Position=0)][hashtable] $buildInfo,
+        [Parameter(Mandatory=$true, ParameterSetName = 'Path', Position=0)][string] $xmlPath
+    )
 
-    return [xml](Get-Content (Join-Path $buildInfo['RepoRootPath'] 'BuildVersion.xml'))
+    if ($PsCmdlet.ParameterSetName -eq "BuildInfo")
+    {
+        return [xml](Get-Content (Join-Path $buildInfo['RepoRootPath'] 'BuildVersion.xml'))
+    }
+    else
+    {
+        return [xml](Get-Content $xmlPath)
+    }
 }


### PR DESCRIPTION
Updates for WhatIf/Confirm standard processing for OneFlow
* Updated scripts to use standard ShouldProcess()
* Updated GH action for PR/CI builds to ignore `OneFlow/*.ps1` as changes there have no impact
    * Still requires a code review and local execution to work.
* Updated common build script module to support a file path for getting the build version XML
    - This was present on the outer layer, but the internal private function to extract the raw XML did not support a path. It does now.