### PR TITLE
Fixes #20 - Updates support to show Number and fix even if 0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     Global references are included in ALL projects in this repository
   -->
   <ItemGroup>
-    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.5-alpha"/>
+    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.6-alpha"/>
 
     <!--
     NOTE: This analyzer is sadly, perpetually in "pre-release" mode. There have been many issues/discussion on the point

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
@@ -192,8 +192,8 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_beta = new CSemVerCI( new CSemVer(20, 1, 4, beta_1_0, ["buildMeta"]), testIndex, testName);
             var ver_delta = new CSemVerCI( new CSemVer(20, 1, 4, delta_0_1, ["buildMeta"]), testIndex, testName);
 
-            Assert.AreEqual("20.1.5-alpha.ci.BuildIndex.BuildName+buildMeta", ver_alpha.ToString());
-            Assert.AreEqual("20.1.5-beta.1.ci.BuildIndex.BuildName+buildMeta", ver_beta.ToString());
+            Assert.AreEqual("20.1.5-alpha.0.0.ci.BuildIndex.BuildName+buildMeta", ver_alpha.ToString());
+            Assert.AreEqual("20.1.5-beta.1.0.ci.BuildIndex.BuildName+buildMeta", ver_beta.ToString());
             Assert.AreEqual("20.1.5-delta.0.1.ci.BuildIndex.BuildName+buildMeta", ver_delta.ToString());
         }
 

--- a/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
@@ -81,10 +81,10 @@ namespace Ubiquity.NET.Versioning.UT
 
             string[] expectedSeq = ["beta", "0", "0"];
             prv = new PrereleaseVersion( "beta", 0, 0 );
-            Assert.IsTrue( expectedSeq.SequenceEqual( prv.FormatElements( alawaysIncludeZero: true ) ) );
+            Assert.IsTrue( expectedSeq.SequenceEqual( prv.FormatElements( alwaysIncludeZero: true ) ) );
 
             expectedSeq = ["beta"];
-            Assert.IsTrue( expectedSeq.SequenceEqual( prv.FormatElements( alawaysIncludeZero: false ) ) );
+            Assert.IsTrue( expectedSeq.SequenceEqual( prv.FormatElements( alwaysIncludeZero: false ) ) );
         }
     }
 }

--- a/src/Ubiquity.NET.Versioning/CSemVerCI.cs
+++ b/src/Ubiquity.NET.Versioning/CSemVerCI.cs
@@ -266,7 +266,7 @@ namespace Ubiquity.NET.Versioning
                 patchP1.Minor,
                 patchP1.Patch,
                 AlphaNumericOrdering.CaseInsensitive,
-                [ .. patchP1.PreRelease, .. ciSeq ],
+                [ .. patchP1.PrereleaseVersion?.FormatElements(alwaysIncludeZero: true) ?? patchP1.PreRelease, .. ciSeq ],
                 patchP1.BuildMeta
             )
         {

--- a/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
+++ b/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
@@ -68,23 +68,23 @@ namespace Ubiquity.NET.Versioning
         public string Name => CSemVerPrereleaseGrammar.ValidPrereleaseNames[ Index ];
 
         /// <summary>Gets this <see cref="PrereleaseVersion"/> as a sequence of strings</summary>
-        /// <param name="alawaysIncludeZero">Indicates whether the result will always include zero values</param>
+        /// <param name="alwaysIncludeZero">Indicates whether the result will always include zero values</param>
         /// <returns>Sequence of strings that represent this instance</returns>
         /// <remarks>
         /// The default behavior is to skip the <see cref="Number"/> value if it and the <see cref="Fix"/>
-        /// value are zero. <paramref name="alawaysIncludeZero"/> is used to override this and show the
+        /// value are zero. <paramref name="alwaysIncludeZero"/> is used to override this and show the
         /// zero value always. (Normally this is only used for a <see cref="CSemVerCI"/>)
         /// </remarks>
         /// <seealso cref="SemVer.PreRelease"/>
         /// <seealso cref="CSemVer"/>
         /// <seealso cref="CSemVerCI"/>
-        public IEnumerable<string> FormatElements( bool alawaysIncludeZero = false )
+        public IEnumerable<string> FormatElements( bool alwaysIncludeZero = false )
         {
             yield return Name;
-            if(Number > 0 || Fix > 0 || alawaysIncludeZero)
+            if(Number > 0 || Fix > 0 || alwaysIncludeZero)
             {
                 yield return Number.ToString( CultureInfo.InvariantCulture );
-                if(Fix >= 1 || alawaysIncludeZero)
+                if(Fix >= 1 || alwaysIncludeZero)
                 {
                     yield return Fix.ToString( CultureInfo.InvariantCulture );
                 }


### PR DESCRIPTION
Fixes #20 - Updates support to show Number and fix even if 0
* CSemVer-CI doesn't spell this (or much else) out explicitly. Instead it relies on examples assuming you see all the aspects of such a thing.
    * For a CSemVer-CI, as long as a Pre-release name exists, then the number and fix are always included even if 0.
* Corrected spelling of parameter for PrereleaseVersion.
* Updated tests to account for inclusion of number and fix in CI prerelease builds
* Updated to latest task that includes fix for the same underlying issue so this package is versioned correctly