### PR TITLE
Updated dependencies and minor corrections

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
-<Project InitialTargets="VerifyProjectSettings;ShowBuildParameters">
-    <Target Name="EnsureBuildOutputPaths" Condition="!EXISTS($(PackageOutputPath))" BeforeTargets="Build;Restore">
-        <MakeDir Directories="$(PackageOutputPath)"/>
+<Project InitialTargets="VerifyProjectSettings;ShowBuildParameters;EnsureBuildOutputPaths">
+    <Target Name="EnsureBuildOutputPaths">
+        <MakeDir Condition="!EXISTS($(PackageOutputPath))" Directories="$(PackageOutputPath)"/>
     </Target>
 
     <Target Name="ShowBuildParameters">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageVersion Include="Sprache" Version="2.3.1" />
     <!-- Tests all use the same framework versions -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.9.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.0.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.0.1" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Ubiquity.NET.Versioning.UT/AssemblyInfo.cs
+++ b/src/Ubiquity.NET.Versioning.UT/AssemblyInfo.cs
@@ -8,6 +8,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 // In SDK-style projects such as this one, several assembly attributes that were historically
 // defined in this file are now automatically added during build and populated with
 // values defined in project properties. For details of which attributes are included
@@ -24,3 +26,11 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant( false )]
 
 [assembly: ExcludeFromCodeCoverage]
+
+// Resolve MSTEST001 - explicitly declare parallelization
+// There are enough tests at the method level to warrant some
+// level of parallelization. However, the class level is the
+// optimal granularity for these tests. The method level ends
+// up with more overhead per thread since the test methods are
+// so small, diminishing the value of parallelization.
+[assembly: Parallelize( Scope = ExecutionScope.ClassLevel )]

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
@@ -205,8 +205,8 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1_same = new CSemVerCI( new CSemVer( 20, 1, 4 ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 20, 1, 4 ), "BuildIndex01", "BuildName02" );
 
-            Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
-            Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
+            Assert.IsLessThan( 0, ver_name_1.CompareTo( ver_name_2 ) );
+            Assert.IsGreaterThan( 0, ver_name_2.CompareTo( ver_name_1 ) );
 
             Assert.AreEqual(0, ver_name_1.CompareTo( ver_name_1_same ));
             Assert.AreEqual(0, ver_name_1_same.CompareTo( ver_name_1 ));
@@ -221,8 +221,8 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1_same = new CSemVerCI( new CSemVer( 20, 1, 4, null, [ "buildMeta" ] ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 20, 1, 4, null, [ "buildMeta" ] ), "BuildIndex01", "BuildName02" );
 
-            Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
-            Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
+            Assert.IsLessThan( 0, ver_name_1.CompareTo( ver_name_2 ) );
+            Assert.IsGreaterThan( 0, ver_name_2.CompareTo( ver_name_1 ) );
 
             Assert.AreEqual(0, ver_name_1.CompareTo( ver_name_1_same ));
             Assert.AreEqual(0, ver_name_1_same.CompareTo( ver_name_1 ));
@@ -238,8 +238,8 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1_same = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1 ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1 ), "BuildIndex01", "BuildName02" );
 
-            Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
-            Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
+            Assert.IsLessThan( 0, ver_name_1.CompareTo( ver_name_2 ) );
+            Assert.IsGreaterThan( 0, ver_name_2.CompareTo( ver_name_1 ) );
 
             Assert.AreEqual(0, ver_name_1.CompareTo( ver_name_1_same ));
             Assert.AreEqual(0, ver_name_1_same.CompareTo( ver_name_1 ));
@@ -257,8 +257,8 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1_same = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1, ["BuildMeta", "MoreMeta"] ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1, ["SomeOhterMeta"] ), "BuildIndex01", "BuildName02" );
 
-            Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
-            Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
+            Assert.IsLessThan( 0, ver_name_1.CompareTo( ver_name_2 ) );
+            Assert.IsGreaterThan( 0, ver_name_2.CompareTo( ver_name_1 ) );
 
             Assert.AreEqual(0, ver_name_1.CompareTo( ver_name_1_same ));
             Assert.AreEqual(0, ver_name_1_same.CompareTo( ver_name_1 ));

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
@@ -26,7 +26,7 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual( 3, ver.Patch );
             Assert.IsFalse( ver.IsPrerelease );
             Assert.IsFalse( ver.PrereleaseVersion.HasValue);
-            Assert.AreEqual( 0, ver.BuildMeta.Length);
+            Assert.IsEmpty( ver.BuildMeta);
 
             var preRelInfo = new PrereleaseVersion(1, 2, 3);
             ImmutableArray<string> expectedMeta = ["buildMeta"];
@@ -48,7 +48,7 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual( 0, ver.Patch );
             Assert.IsFalse( ver.IsPrerelease );
             Assert.IsFalse( ver.PrereleaseVersion.HasValue);
-            Assert.AreEqual( 0, ver.BuildMeta.Length);
+            Assert.IsEmpty( ver.BuildMeta);
         }
 
         [TestMethod]
@@ -80,11 +80,11 @@ namespace Ubiquity.NET.Versioning.UT
             var val = new CSemVer(1,2,3);
             var val2 = new CSemVer(1,2,3);
             var valp1 = new CSemVer(1,2,4); // "+1"
-            Assert.IsTrue(val.CompareTo(valm1) > 0, "[CompareTo] val > (val -1)");
-            Assert.IsTrue(valm1.CompareTo(val) < 0, "[CompareTo] (val - 1) < val");
+            Assert.IsGreaterThan( 0, val.CompareTo( valm1 ), "[CompareTo] val > (val -1)");
+            Assert.IsLessThan( 0, valm1.CompareTo( val ), "[CompareTo] (val - 1) < val");
             Assert.AreEqual(0, val.CompareTo(val2), "[CompareTo] val == val");
-            Assert.IsTrue(val.CompareTo(valp1) < 0, "[CompareTo] val < (val + 1)");
-            Assert.IsTrue(valp1.CompareTo(val) > 0, "[CompareTo] (val + 1) > val");
+            Assert.IsLessThan( 0, val.CompareTo( valp1 ), "[CompareTo] val < (val + 1)");
+            Assert.IsGreaterThan( 0, valp1.CompareTo( val ), "[CompareTo] (val + 1) > val");
 
             // Ensure operator variants are correct
             // (They should internally use CompareTo, this verifies correct behavior
@@ -149,7 +149,7 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual(number, ver.PrereleaseVersion.Value.Number, exp);
             Assert.AreEqual(fix, ver.PrereleaseVersion.Value.Fix, exp);
             Assert.IsNotNull(ver.BuildMeta, $"non-nullable property should not be null for '{exp}'");
-            Assert.AreEqual(0, ver.BuildMeta.Length, $"non-nullable property should be empty if not set for '{exp}'");
+            Assert.IsEmpty( ver.BuildMeta, $"non-nullable property should be empty if not set for '{exp}'");
             Assert.AreEqual(orderedVersion, ver.OrderedVersion , $"builds should have the same ordered version number provided for '{exp}'");
         }
 
@@ -168,7 +168,7 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.IsFalse(ver.PrereleaseVersion.HasValue, exp);
             Assert.IsFalse(ver.IsPrerelease, exp);
             Assert.IsNotNull(ver.BuildMeta, $"non-nullable property should not be null for '{exp}'");
-            Assert.AreEqual(0, ver.BuildMeta.Length, $"non-nullable property should be empty if not set for '{exp}'");
+            Assert.IsEmpty( ver.BuildMeta, $"non-nullable property should be empty if not set for '{exp}'");
             Assert.AreEqual(orderedVersion, ver.OrderedVersion , $"should have the same ordered version number as provided for '{exp}'");
         }
     }

--- a/src/Ubiquity.NET.Versioning.UT/SemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/SemVerTests.cs
@@ -25,23 +25,23 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual( 1, sv1.Major );
             Assert.AreEqual( 2, sv1.Minor );
             Assert.AreEqual( 3, sv1.Patch );
-            Assert.AreEqual( 0, sv1.PreRelease.Length );
-            Assert.AreEqual( 0, sv1.BuildMeta.Length );
+            Assert.IsEmpty( sv1.PreRelease);
+            Assert.IsEmpty( sv1.BuildMeta);
 
             var sv2 = new SemVer(1, 2, 3, AlphaNumericOrdering.CaseSensitive, ["pre-rel"]);
             Assert.AreEqual( 1, sv2.Major );
             Assert.AreEqual( 2, sv2.Minor );
             Assert.AreEqual( 3, sv2.Patch );
-            Assert.AreEqual( 1, sv2.PreRelease.Length );
+            Assert.HasCount( 1, sv2.PreRelease );
             Assert.AreEqual( "pre-rel", sv2.PreRelease[ 0 ] );
-            Assert.AreEqual( 0, sv2.BuildMeta.Length );
+            Assert.IsEmpty( sv2.BuildMeta);
 
             var sv3 = new SemVer(1, 2, 3, AlphaNumericOrdering.CaseSensitive, [], ["meta"]);
             Assert.AreEqual( 1, sv3.Major );
             Assert.AreEqual( 2, sv3.Minor );
             Assert.AreEqual( 3, sv3.Patch );
-            Assert.AreEqual( 0, sv3.PreRelease.Length );
-            Assert.AreEqual( 1, sv3.BuildMeta.Length );
+            Assert.IsEmpty( sv3.PreRelease);
+            Assert.HasCount( 1, sv3.BuildMeta );
             Assert.AreEqual( "meta", sv3.BuildMeta[ 0 ] );
         }
 
@@ -73,12 +73,12 @@ namespace Ubiquity.NET.Versioning.UT
                 var lhs = sample[i-1];
                 var rhs = sample[i];
 
-                Assert.IsTrue( lhs.CompareTo( rhs ) < 0, $"'{lhs}' should compare less than '{rhs}'" );
+                Assert.IsLessThan( 0, lhs.CompareTo( rhs ), $"'{lhs}' should compare less than '{rhs}'" );
 
                 // inverted should produce correct results too.
-                Assert.IsTrue( rhs.CompareTo( lhs ) > 0, $"'{rhs}' should compare greater than '{lhs}'" );
+                Assert.IsGreaterThan( 0, rhs.CompareTo( lhs ), $"'{rhs}' should compare greater than '{lhs}'" );
 
-                Assert.IsTrue( lhs.CompareTo( null ) > 0, "Any version should compare greater than null" );
+                Assert.IsGreaterThan( 0, lhs.CompareTo( null ), "Any version should compare greater than null" );
 #pragma warning disable IDE0002 // Simplify Member Access
                 // Simplification results in a different API call! Test is for a specific case
                 Assert.IsTrue( SemVer.Equals( null, null ) );
@@ -163,8 +163,8 @@ namespace Ubiquity.NET.Versioning.UT
             Assert.AreEqual( expected.Major, actual.Major, $"Major should match for '{input}'" );
             Assert.AreEqual( expected.Minor, actual.Minor, $"Minor should match for '{input}'" );
             Assert.AreEqual( expected.Patch, actual.Patch, $"Patch should match for '{input}'" );
-            Assert.AreEqual( expected.PreRelease.Length, actual.PreRelease.Length, $"PreRelease.Count should match for '{input}'" );
-            Assert.AreEqual( expected.BuildMeta.Length, actual.BuildMeta.Length, $"BuildMeta.Count should match for '{input}'" );
+            Assert.HasCount( expected.PreRelease.Length, actual.PreRelease, $"PreRelease.Count should match for '{input}'" );
+            Assert.HasCount( expected.BuildMeta.Length, actual.BuildMeta, $"BuildMeta.Count should match for '{input}'" );
             for(int i = 0; i < expected.PreRelease.Length; ++i)
             {
                 Assert.AreEqual( expected.PreRelease[ i ], actual.PreRelease[ i ], $"PreRelease[{i}] should match for '{input}'" );

--- a/src/Ubiquity.NET.Versioning.UT/ValidationWithTask.cs
+++ b/src/Ubiquity.NET.Versioning.UT/ValidationWithTask.cs
@@ -102,7 +102,7 @@ namespace Ubiquity.NET.Versioning.UT
                 // Assert.AreEqual( expectedVersion.Index, actualCI.Index);
                 Assert.AreEqual( expectedVersion.Name, actualCI.Name);
 
-                Assert.AreEqual( expectedVersion.PreRelease.Length, actualCI.PreRelease.Length, "prerelease sequence should have matching element count" );
+                Assert.HasCount( expectedVersion.PreRelease.Length, actualCI.PreRelease, "prerelease sequence should have matching element count" );
             }
             else
             {

--- a/src/Ubiquity.NET.Versioning/Comparison/SemVerComparer.cs
+++ b/src/Ubiquity.NET.Versioning/Comparison/SemVerComparer.cs
@@ -22,7 +22,7 @@ namespace Ubiquity.NET.Versioning.Comparison
     /// </remarks>
     [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "File name reflects purpose of these classes" )]
     [SuppressMessage( "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Tightly coupled types share file scoped implementations" )]
-    internal static class CaseSensitive
+    public static class CaseSensitive
     {
         /// <summary>Gets a comparer that compares the values of pre-release identifier</summary>
         /// <remarks>

--- a/src/Ubiquity.NET.Versioning/Properties/Resources.Designer.cs
+++ b/src/Ubiquity.NET.Versioning/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Ubiquity.NET.Versioning.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -111,6 +111,15 @@ namespace Ubiquity.NET.Versioning.Properties {
         internal static string odd_file_versions_are_reserved_for_CI {
             get {
                 return ResourceManager.GetString("odd_file_versions_are_reserved_for_CI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unrecognized format provider. Provider must provide formatting for {0}.
+        /// </summary>
+        internal static string Unrecognized_format_provider_Provider_must_provide_formatting_for_0 {
+            get {
+                return ResourceManager.GetString("Unrecognized_format_provider_Provider_must_provide_formatting_for_0", resourceCulture);
             }
         }
         

--- a/src/Ubiquity.NET.Versioning/Properties/Resources.resx
+++ b/src/Ubiquity.NET.Versioning/Properties/Resources.resx
@@ -145,4 +145,8 @@
     <value>'{0}' must be in range {1}. {2}</value>
     <comment>{0} - Value name; {1} - range notation for the value; {2} post message text (Usually a spec reference)</comment>
   </data>
+  <data name="Unrecognized_format_provider_Provider_must_provide_formatting_for_0" xml:space="preserve">
+    <value>Unrecognized format provider. Provider must provide formatting for {0}</value>
+    <comment>Format provider for a parse of a SemVer string doesn't report the ordering required.</comment>
+  </data>
 </root>

--- a/src/Ubiquity.NET.Versioning/Properties/ResourcesExtensions.cs
+++ b/src/Ubiquity.NET.Versioning/Properties/ResourcesExtensions.cs
@@ -13,7 +13,7 @@ namespace Ubiquity.NET.Versioning.Properties
 {
     internal static class ResourcesExtensions
     {
-        internal static CompositeFormat AsFormat([NotNull] this string? self)
+        internal static CompositeFormat ParseAsFormat([NotNull][StringSyntax(StringSyntaxAttribute.CompositeFormat)] this string? self)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(self);
             return CompositeFormat.Parse(self);
@@ -37,22 +37,22 @@ namespace Ubiquity.NET.Versioning.Properties
             return string.Format(CultureInfo.CurrentCulture, self, arg0, arg1, arg3);
         }
 
-        internal static string Format<TArg0>([NotNull]this string? self, TArg0 arg0)
+        internal static string Format<TArg0>([NotNull][StringSyntax( StringSyntaxAttribute.CompositeFormat )] this string? self, TArg0 arg0)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(self);
-            return string.Format(CultureInfo.CurrentCulture, self.AsFormat(), arg0);
+            return string.Format(CultureInfo.CurrentCulture, self.ParseAsFormat(), arg0);
         }
 
-        internal static string Format<TArg0, TArg1>([NotNull]this string? self, TArg0 arg0, TArg1 arg1)
+        internal static string Format<TArg0, TArg1>([NotNull][StringSyntax( StringSyntaxAttribute.CompositeFormat )] this string? self, TArg0 arg0, TArg1 arg1)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(self);
-            return string.Format(CultureInfo.CurrentCulture, self.AsFormat(), arg0, arg1);
+            return string.Format(CultureInfo.CurrentCulture, self.ParseAsFormat(), arg0, arg1);
         }
 
-        internal static string Format<TArg0, TArg1, TArg3>([NotNull]this string? self, TArg0 arg0, TArg1 arg1, TArg3 arg3)
+        internal static string Format<TArg0, TArg1, TArg3>([NotNull][StringSyntax( StringSyntaxAttribute.CompositeFormat )] this string? self, TArg0 arg0, TArg1 arg1, TArg3 arg3)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(self);
-            return string.Format(CultureInfo.CurrentCulture, self.AsFormat(), arg0, arg1, arg3);
+            return string.Format(CultureInfo.CurrentCulture, self.ParseAsFormat(), arg0, arg1, arg3);
         }
     }
 }

--- a/src/Ubiquity.NET.Versioning/SemVer.cs
+++ b/src/Ubiquity.NET.Versioning/SemVer.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
@@ -73,17 +72,17 @@ namespace Ubiquity.NET.Versioning
 
             if(!preRel.IsDefaultOrEmpty)
             {
-                PreRelease = ValidateElementsWithParser(preRel, SemVerGrammar.PreReleaseIdentifier);
+                PreRelease = ValidateElementsWithParser( preRel, SemVerGrammar.PreReleaseIdentifier );
             }
 
             if(!build.IsDefaultOrEmpty)
             {
-                BuildMeta = ValidateElementsWithParser(build, SemVerGrammar.BuildIdentifier);
+                BuildMeta = ValidateElementsWithParser( build, SemVerGrammar.BuildIdentifier );
             }
 
-            if( sortOrdering == AlphaNumericOrdering.None)
+            if(sortOrdering == AlphaNumericOrdering.None)
             {
-                throw new ArgumentException("Sort ordering of 'None' is an invalid value", nameof(sortOrdering));
+                throw new ArgumentException( "Sort ordering of 'None' is an invalid value", nameof( sortOrdering ) );
             }
 
             AlphaNumericOrdering = sortOrdering;
@@ -121,13 +120,13 @@ namespace Ubiquity.NET.Versioning
         public override string ToString( )
         {
             var bldr = new StringBuilder($"{Major}.{Minor}.{Patch}");
-            if( PreRelease.Length > 0 )
+            if(PreRelease.Length > 0)
             {
                 bldr.Append( '-' )
                     .AppendJoin( '.', PreRelease );
             }
 
-            if( BuildMeta.Length > 0 )
+            if(BuildMeta.Length > 0)
             {
                 bldr.Append( '+' )
                     .AppendJoin( '.', BuildMeta );
@@ -135,6 +134,8 @@ namespace Ubiquity.NET.Versioning
 
             return bldr.ToString();
         }
+
+        #region Relational operators
 
         /// <inheritdoc/>
         /// <exception cref="InvalidOperationException">The <see cref="AlphaNumericOrdering"/> for both sides does not match</exception>
@@ -153,35 +154,33 @@ namespace Ubiquity.NET.Versioning
                 return 1;
             }
 
-            if (AlphaNumericOrdering != other.AlphaNumericOrdering)
+            if(AlphaNumericOrdering != other.AlphaNumericOrdering)
             {
-                throw new InvalidOperationException("SemVer values have different AlphaNumericOrdering, direct comparison is not supported.");
+                throw new InvalidOperationException( "SemVer values have different AlphaNumericOrdering, direct comparison is not supported." );
             }
 
             return AlphaNumericOrdering == AlphaNumericOrdering.CaseSensitive
-                 ? Comparison.CaseSensitive.SemVer.Compare(this, other)
-                 : Comparison.CaseInsensitive.SemVer.Compare(this, other);
+                 ? Comparison.CaseSensitive.SemVer.Compare( this, other )
+                 : Comparison.CaseInsensitive.SemVer.Compare( this, other );
         }
-
-        #region Relational operators
 
         /// <inheritdoc/>
         public override bool Equals( object? obj )
         {
-            return obj is SemVer v && Equals(v);
+            return obj is SemVer v && Equals( v );
         }
 
         /// <inheritdoc/>
         public override int GetHashCode( )
         {
             // NOTE: Build meta does not contribute to ordering and therefore does not contribute to the hash
-            return HashCode.Combine(AlphaNumericOrdering, Major, Minor, Patch, PreRelease);
+            return HashCode.Combine( AlphaNumericOrdering, Major, Minor, Patch, PreRelease );
         }
 
         /// <inheritdoc/>
         public bool Equals( SemVer? other )
         {
-            return CompareTo(other) == 0;
+            return CompareTo( other ) == 0;
         }
 
         /// <inheritdoc/>
@@ -255,19 +254,25 @@ namespace Ubiquity.NET.Versioning
         /// <inheritdoc cref="Parse(string, IFormatProvider?)" path="/remarks"/>
         public static bool TryParse( [NotNullWhen( true )] string? s, IFormatProvider? provider, [MaybeNullWhen( false )] out SemVer result )
         {
-            return TryParseIncludeDerived(s, provider, out result, out _);
+            return TryParseIncludeDerived( s, provider, out result, out _ );
         }
 
         /// <summary>Tries to parse a string into a semantic version providing details of any failures</summary>
         /// <param name="s">Input string to parse</param>
-        /// <param name="provider">Formatting provider to use</param>
+        /// <param name="provider">Formatting provider to use [<see cref="SemVerFormatProvider.CaseSensitive"/> or <see cref="SemVerFormatProvider.CaseInsensitive"/>]</param>
         /// <param name="result">Resulting <see cref="SemVer"/> if parse succeeds</param>
         /// <param name="ex">Exception data for any errors or <see langword="null"/> if parse succeeded</param>
         /// <returns><see langword="true"/> if string successfully parsed or <see langword="false"/> if not</returns>
         /// <remarks>
-        /// This does NOT consider derived types. It is used by the general parsing as well as parsing of derived types
-        /// themselves.
+        /// <para>This does NOT consider derived types. It is used by the general parsing as well as parsing of derived types
+        /// themselves.</para>
+        /// <para>The sort ordering for alpha numeric identifies in the version is specified by the <paramref name="provider"/>.
+        /// It must provide a value for the <see cref="AlphaNumericOrdering"/> in it's <see cref="IFormatProvider.GetFormat(Type?)"/>
+        /// otherwise an exception occurs.
+        /// </para>
         /// </remarks>
+        /// <exception cref="ArgumentNullException">One or more of the arguments provided is <see langword="null"/></exception>
+        /// <exception cref="ArgumentException">The <paramref name="provider"/> does not support the <see cref="AlphaNumericOrdering"/> format</exception>
         internal static bool TryParse(
             [NotNull] string? s,
             IFormatProvider? provider,
@@ -278,8 +283,14 @@ namespace Ubiquity.NET.Versioning
             ArgumentNullException.ThrowIfNull( s );
 
             provider ??= SemVerFormatProvider.CaseSensitive;
+            if(provider is null)
+            {
+                string msg = Resources.Unrecognized_format_provider_Provider_must_provide_formatting_for_0.Format( nameof( AlphaNumericOrdering ) );
+                throw new ArgumentException( msg, nameof(provider) );
+            }
+
             IResult<SemVer> parseResult = SemVerGrammar.SemanticVersion(provider.GetOrdering()).TryParse(s);
-            if(parseResult.Failed(out ex))
+            if(parseResult.Failed( out ex ))
             {
                 result = default;
                 return false;
@@ -300,11 +311,11 @@ namespace Ubiquity.NET.Versioning
             result = default;
             ex = default;
 
-            if(TryParse(s, provider, out SemVer? baseVer, out ex))
+            if(TryParse( s, provider, out SemVer? baseVer, out ex ))
             {
                 // if caller expects case sensitivity then CSmeVer[-CI] are off the table.
                 // Those are explicitly case insensitive.
-                if( provider.IsCaseSensitive())
+                if(provider.IsCaseSensitive())
                 {
                     result = baseVer;
                     return true;
@@ -312,13 +323,13 @@ namespace Ubiquity.NET.Versioning
 
                 // expect case insensitive so consider CSemVer/CSemVerCI
 
-                if(CSemVer.TryFrom(baseVer, out CSemVer? ver, out ex))
+                if(CSemVer.TryFrom( baseVer, out CSemVer? ver, out ex ))
                 {
                     result = ver;
                     return true;
                 }
 
-                if(CSemVerCI.TryFrom(baseVer, out CSemVerCI? ciVer, out ex))
+                if(CSemVerCI.TryFrom( baseVer, out CSemVerCI? ciVer, out ex ))
                 {
                     result = ciVer;
                     return true;
@@ -334,18 +345,9 @@ namespace Ubiquity.NET.Versioning
         #endregion
 
         private static ImmutableArray<string> ValidateElementsWithParser(
-            IEnumerable<string>? value,
-            Parser<string> parser,
-            [CallerArgumentExpression(nameof(value))] string? exp = null
-            )
-        {
-            return value is null ? [] : ValidateElementsWithParser( [.. value], parser, exp);
-        }
-
-        private static ImmutableArray<string> ValidateElementsWithParser(
             ImmutableArray<string>? value,
             Parser<string> parser,
-            [CallerArgumentExpression(nameof(value))] string? exp = null
+            [CallerArgumentExpression( nameof( value ) )] string? exp = null
             )
         {
             if(value is null)
@@ -358,7 +360,7 @@ namespace Ubiquity.NET.Versioning
                 IResult<string> parseResult = parser.TryParse(part);
                 if(!parseResult.WasSuccessful)
                 {
-                    throw new FormatException( Resources.exp_0_contains_invalid_value_1_2.Format(exp, part, parseResult.Message) );
+                    throw new FormatException( Resources.exp_0_contains_invalid_value_1_2.Format( exp, part, parseResult.Message ) );
                 }
             }
 


### PR DESCRIPTION
Updated dependencies.
* This generally impacts only the testing as the test adapter and framework are bumped.
* Resolved MSTEST* analyzer warnings by adjusting code to use new APIs
* Added parallelization optimizations for the test runs.
    - on a 24 Core machine this amounted to ~70% improvement in completion time
        - Though the total time was under 1s, it is now under 100ms
* Adjusted repo wide targets to ensure `NuGet` forlder exists
    - This ensures that it exists for any restore so that it is considered as
      a valid source of packages.
        - This is useful for debugging/testing of CI variants of dependent packages
* Made comparison CaseSensitive static class public so it is usable by callers that need explicit handling of potentially mixed sources.
    - This can lead to unexpected results even if consistent. The use of case in SemVer is sadly ambiguos and different major public repos (NuGet and npm as examples) have chosen different behaviors so users need to be clear on the behavior. Use of explicit overrides allows
such a thing in the case of mixed case expectation.
- Renamed `ResourcesExtensions.AsFormat()` -> `ResourcesExtensions.ParseAsFormat()` for greater clarity of intent/behavior.
* Added use of `StringSyntaxAttribute` to resource extensions.
* Added check for formatter support of ordering to ensure it reports an error message that hopefully makes sense.
* General re-formatting and docs clarifications